### PR TITLE
update car and logger middleware

### DIFF
--- a/server/prisma/migrations/20250305044257_update_car/migration.sql
+++ b/server/prisma/migrations/20250305044257_update_car/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - Added the required column `address` to the `cars` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `autoGearbox` to the `cars` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `fuelType` to the `cars` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `numSeats` to the `cars` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "FuelType" AS ENUM ('DIESEL', 'PETROL', 'ELECTRIC', 'HYBRID');
+
+-- AlterTable
+ALTER TABLE "cars" ADD COLUMN     "address" TEXT NOT NULL,
+ADD COLUMN     "autoGearbox" BOOLEAN NOT NULL,
+ADD COLUMN     "fuelType" "FuelType" NOT NULL,
+ADD COLUMN     "numSeats" INTEGER NOT NULL;

--- a/server/prisma/migrations/20250305045900_update_car/migration.sql
+++ b/server/prisma/migrations/20250305045900_update_car/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `mileage` on the `cars` table. All the data in the column will be lost.
+  - Added the required column `kilomiters` to the `cars` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "cars" DROP COLUMN "mileage",
+ADD COLUMN     "kilomiters" INTEGER NOT NULL;

--- a/server/prisma/migrations/20250305045956_update_car/migration.sql
+++ b/server/prisma/migrations/20250305045956_update_car/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `kilomiters` on the `cars` table. All the data in the column will be lost.
+  - Added the required column `kilometers` to the `cars` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "cars" DROP COLUMN "kilomiters",
+ADD COLUMN     "kilometers" INTEGER NOT NULL;

--- a/server/prisma/schema/car.prisma
+++ b/server/prisma/schema/car.prisma
@@ -3,15 +3,26 @@ enum CarStatus {
     RENTED
 }
 
+enum FuelType {
+    DIESEL
+    PETROL
+    ELECTRIC
+    HYBRID
+}
+
 model Car {
     id            String        @id @default(uuid())
     make          String
     model         String
     year          Int
-    mileage       Int
+    kilometers    Int
     description   String
     dailyPrice    Float
     licensePlate  String
+    numSeats      Int
+    address       String
+    autoGearbox   Boolean
+    fuelType      FuelType
     status        CarStatus     @default(AVAILABLE)
     carCategories CarCategory[]
     reviews       Review[]

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -26,6 +26,7 @@ import { BullBoardModule } from '@bull-board/nestjs';
 import { ExpressAdapter } from '@bull-board/express';
 import { TransactionModule } from './modules/transaction/transaction.module';
 import { ReviewModule } from './modules/review/review.module';
+import { LoggerMiddleware } from './middlewares/logger.middleware';
 
 @Module({
   imports: [
@@ -122,4 +123,8 @@ import { ReviewModule } from './modules/review/review.module';
     },
   ],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(LoggerMiddleware).forRoutes('*');
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -21,9 +21,16 @@ async function bootstrap() {
     }),
   });
 
-  configSwagger(app);
   const configService = app.get(ConfigService);
-  app.use(morgan('dev'));
+
+  app.enableCors({
+    origin: configService.get('FRONTEND_URL') || 'http://localhost:5173',
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    credentials: true,
+  });
+
+  configSwagger(app);
+  // app.use(morgan('dev'));
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/server/src/middlewares/logger.middleware.ts
+++ b/server/src/middlewares/logger.middleware.ts
@@ -1,0 +1,36 @@
+// src/middleware/logger.middleware.ts
+import winstonInstance from '@/configs/winston.config';
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const { method, originalUrl, ip } = req;
+    const start = process.hrtime();
+
+    // Add response tracking
+    const originalSend = res.send;
+    let responseBody: any;
+
+    res.send = function (body) {
+      responseBody = body;
+      return originalSend.call(this, body);
+    };
+
+    res.on('finish', () => {
+      const diff = process.hrtime(start);
+      const responseTime = (diff[0] * 1e3 + diff[1] * 1e-6).toFixed(3); // More precise timing
+      const contentLength =
+        res.get('content-length') || (responseBody ? responseBody.length : 0);
+
+      winstonInstance.log({
+        level: res.statusCode >= 400 ? 'error' : 'info',
+        message: `${method} ${originalUrl} ${res.statusCode} - ${responseTime}ms - ${contentLength}`,
+        context: 'HTTP',
+        ip,
+      });
+    });
+    next();
+  }
+}

--- a/server/src/modules/car/dto/create.request.dto.ts
+++ b/server/src/modules/car/dto/create.request.dto.ts
@@ -1,7 +1,9 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { CarStatus } from '@prisma/client';
+import { CarStatus, FuelType } from '@prisma/client';
 import {
   IsArray,
+  IsBoolean,
+  IsEnum,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -24,7 +26,7 @@ export class CreateCarRequestDTO {
 
   @IsNotEmpty()
   @IsNumber()
-  mileage: number;
+  kilometers: number;
 
   @IsOptional()
   @IsString()
@@ -38,6 +40,22 @@ export class CreateCarRequestDTO {
   @IsString()
   licensePlate: string;
 
+  @IsEnum(FuelType)
+  @IsNotEmpty()
+  fuelType: FuelType;
+
+  @IsNotEmpty()
+  @IsString()
+  address: string;
+
+  @IsNotEmpty()
+  @IsNumber()
+  numSeats: number;
+
+  @IsNotEmpty()
+  @IsBoolean()
+  autoGearbox: boolean;
+
   @ApiPropertyOptional({ type: [String] })
   @IsOptional()
   @IsArray()
@@ -48,5 +66,5 @@ export class CreateCarRequestDTO {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  categoryIds: string[];
+  categoryIds?: string[];
 }

--- a/server/src/modules/car/dto/response.dto.ts
+++ b/server/src/modules/car/dto/response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Car, CarStatus } from '@prisma/client';
+import { $Enums, Car, CarStatus, FuelType } from '@prisma/client';
 import { Exclude, Expose, Type } from 'class-transformer';
 
 export class CarResponseDTO implements Car {
@@ -19,7 +19,7 @@ export class CarResponseDTO implements Car {
   year: number;
 
   @Expose()
-  mileage: number;
+  kilometers: number;
 
   @Expose()
   description: string;
@@ -29,6 +29,19 @@ export class CarResponseDTO implements Car {
 
   @Expose()
   licensePlate: string;
+
+  @Expose()
+  @ApiProperty({ enum: FuelType, enumName: 'fuelType' })
+  fuelType: FuelType;
+
+  @Expose()
+  address: string;
+
+  @Expose()
+  numSeats: number;
+
+  @Expose()
+  autoGearbox: boolean;
 
   @Expose()
   @ApiProperty({ enum: CarStatus, enumName: 'carStatus' })

--- a/server/src/modules/database/database.service.ts
+++ b/server/src/modules/database/database.service.ts
@@ -68,6 +68,6 @@ export class DatabaseService extends PrismaClient implements OnModuleInit {
         role: 'ADMIN',
       },
     });
-    this.logger.log('Create admin account successfully');
+    this.logger.log('Created admin account successfully');
   }
 }


### PR DESCRIPTION
This pull request includes several updates to the `cars` table schema, middleware configuration, and DTOs in the server module. The changes aim to enhance the data structure, improve logging, and update request and response handling for car-related operations.

Schema updates:

* Added new columns `address`, `autoGearbox`, `fuelType`, and `numSeats` to the `cars` table without default values.
* Dropped the `mileage` column and added the `kilomiters` column, followed by correcting the column name to `kilometers`. [[1]](diffhunk://#diff-368610a364df24c9624995b21d1190b17ac9e812fc0066c504fe65cc054735e7R1-R10) [[2]](diffhunk://#diff-6e8b0c08d7b22c1a7a1f7b34e2498a7b6f053d65fda1eaf6be9ddce81c0638c2R1-R10)
* Introduced a new enum `FuelType` with values `DIESEL`, `PETROL`, `ELECTRIC`, and `HYBRID` in the `car.prisma` schema.

Middleware configuration:

* Added `LoggerMiddleware` to log HTTP requests with precise timing and response details.
* Configured the middleware in `app.module.ts` to apply `LoggerMiddleware` globally. [[1]](diffhunk://#diff-4e8033eb0f9fd87924c445b7ac0f1c1192d4890fc1589b2fad2679797d4f4ce0R29) [[2]](diffhunk://#diff-4e8033eb0f9fd87924c445b7ac0f1c1192d4890fc1589b2fad2679797d4f4ce0L125-R130)

DTO updates:

* Updated `CreateCarRequestDTO` to include new fields: `kilometers`, `fuelType`, `address`, `numSeats`, and `autoGearbox`. [[1]](diffhunk://#diff-64058b7e021951463ada2fdcaafbe539c26e1aa979f2f991af19d9a2057a5925L27-R29) [[2]](diffhunk://#diff-64058b7e021951463ada2fdcaafbe539c26e1aa979f2f991af19d9a2057a5925R43-R58) [[3]](diffhunk://#diff-64058b7e021951463ada2fdcaafbe539c26e1aa979f2f991af19d9a2057a5925L51-R69)
* Updated `CarResponseDTO` to reflect the new fields and changes in the `Car` model. [[1]](diffhunk://#diff-28c504baee034e07a9b60931bf22c9ae805684c56e45cae4d733dd409cbe9374L22-R22) [[2]](diffhunk://#diff-28c504baee034e07a9b60931bf22c9ae805684c56e45cae4d733dd409cbe9374R33-R45)