### PR TITLE
update forgot password

### DIFF
--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -158,10 +158,9 @@ export class AuthService {
       exp: this.FORGOT_PASSWORD_EXPIRATION_TIME,
     });
 
-    await this.emailService.sendUserResetPasswordEmail(
-      email,
-      resetPasswordToken,
-    );
+    console.log('resetPasswordToken', resetPasswordToken);
+
+    await this.emailService.sendForgotPasswordEmail(email, resetPasswordToken);
   }
 
   async resetPassword(dto: ResetPasswordRequestDTO): Promise<void> {
@@ -226,6 +225,6 @@ export class AuthService {
       exp: this.VERIFY_ACCOUNT_EXPIRATION_TIME,
     });
 
-    await this.emailService.sendUserVerifyEmail(email, fullName, verifyToken);
+    await this.emailService.sendVerifyEmail(email, fullName, verifyToken);
   }
 }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -146,6 +146,10 @@ export class AuthService {
     );
   }
 
+  async deleteRefreshToken(user_id: string): Promise<void> {
+    await this.cacheService.del(user_id);
+  }
+
   async forgotPassword(email: string): Promise<void> {
     const user = await this.userService.findByEmail(email);
     const payload: ResetPasswordTokenPayload = {
@@ -158,9 +162,13 @@ export class AuthService {
       exp: this.FORGOT_PASSWORD_EXPIRATION_TIME,
     });
 
-    console.log('resetPasswordToken', resetPasswordToken);
+    const fullName = `${user.firstName} ${user.lastName}`;
 
-    await this.emailService.sendForgotPasswordEmail(email, resetPasswordToken);
+    await this.emailService.sendForgotPasswordEmail(
+      fullName,
+      email,
+      resetPasswordToken,
+    );
   }
 
   async resetPassword(dto: ResetPasswordRequestDTO): Promise<void> {
@@ -184,6 +192,9 @@ export class AuthService {
       { id: user.id },
       { password: hashedPassword },
     );
+
+    this.logger.log(`Password reset for user ${user.id}`);
+    await this.deleteRefreshToken(user.id);
   }
 
   async verifyAccount(token: string): Promise<void> {

--- a/server/src/modules/email/email.service.ts
+++ b/server/src/modules/email/email.service.ts
@@ -58,13 +58,22 @@ export class EmailService {
       ...data,
     });
   }
-  async sendForgotPasswordEmail(email: string, token: string): Promise<void> {
+  async sendForgotPasswordEmail(
+    name: string,
+    email: string,
+    token: string,
+  ): Promise<void> {
     const frontendUrl = this.configService.get<string>('FRONTEND_URL');
     const resetPasswordLink = `${frontendUrl}/auth/reset-password?token=${token}`;
+    console.log('resetPasswordLink', resetPasswordLink);
     await this.sendEmail({
       to: email,
       subject: 'Reset your password',
-      html: this.convertToHTML('auth/forgotPassword', { resetPasswordLink }),
+      html: this.convertToHTML('auth/forgotPassword', {
+        email,
+        name,
+        resetPasswordLink,
+      }),
     });
   }
 

--- a/server/src/modules/email/email.service.ts
+++ b/server/src/modules/email/email.service.ts
@@ -58,18 +58,17 @@ export class EmailService {
       ...data,
     });
   }
-  async sendUserResetPasswordEmail(
-    email: string,
-    token: string,
-  ): Promise<void> {
+  async sendForgotPasswordEmail(email: string, token: string): Promise<void> {
+    const frontendUrl = this.configService.get<string>('FRONTEND_URL');
+    const resetPasswordLink = `${frontendUrl}/auth/reset-password?token=${token}`;
     await this.sendEmail({
       to: email,
       subject: 'Reset your password',
-      html: this.convertToHTML('auth/forgotPassword', { token }),
+      html: this.convertToHTML('auth/forgotPassword', { resetPasswordLink }),
     });
   }
 
-  async sendUserVerifyEmail(
+  async sendVerifyEmail(
     email: string,
     fullName: string,
     token: string,

--- a/server/src/templates/auth/forgotPassword.pug
+++ b/server/src/templates/auth/forgotPassword.pug
@@ -54,11 +54,11 @@ div(role='article', aria-roledescription='email', aria-label='Reset your Passwor
                       span(style='font-weight: 600;') 49.34.185.199
                       |  .
                     p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0; margin-bottom: 24px;") Use this link to reset your password and login.
-                    a(href='https://pixinvent.com?reset_password_url', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin-bottom: 24px; display: block; font-size: 16px; line-height: 100%; color: #7367f0; text-decoration: none;") #{token}
+                    a(href=`${resetPasswordLink}`, style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin-bottom: 24px; display: block; font-size: 16px; line-height: 100%; color: #7367f0; text-decoration: none;") #{frontendUrl}/reset-password?token=xxxxx
                     table(cellpadding='0', cellspacing='0', role='presentation')
                       tr
                         td(style="mso-line-height-rule: exactly; mso-padding-alt: 16px 24px; border-radius: 4px; background-color: #7367f0; font-family: Montserrat, -apple-system, 'Segoe UI', sans-serif;")
-                          a(href='https://pixinvent.com?reset_password_url', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; display: block; padding-left: 24px; padding-right: 24px; padding-top: 16px; padding-bottom: 16px; font-size: 16px; font-weight: 600; line-height: 100%; color: #ffffff; text-decoration: none;") Reset Password &rarr;
+                          a(href=`${resetPasswordLink}`, style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; display: block; padding-left: 24px; padding-right: 24px; padding-top: 16px; padding-bottom: 16px; font-size: 16px; font-weight: 600; line-height: 100%; color: #ffffff; text-decoration: none;") Reset Password &rarr;
                     p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0; margin-top: 24px; margin-bottom: 24px;")
                       span(style='font-weight: 600;') Note:
                       |  This link is valid for 1 hour from the time it was
@@ -100,4 +100,3 @@ div(role='article', aria-roledescription='email', aria-label='Reset your Passwor
                       | .
                 tr
                   td(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; height: 16px;")
- 

--- a/server/src/templates/auth/forgotPassword.pug
+++ b/server/src/templates/auth/forgotPassword.pug
@@ -28,7 +28,7 @@ head
     padding-bottom: 32px !important;
     }
     }
-div(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; display: none;") A request to reset password was received from your PixInvent Account
+div(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; display: none;") A request to reset password was received from your CRS Account
 div(role='article', aria-roledescription='email', aria-label='Reset your Password', lang='en', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly;")
   table(style="width: 100%; font-family: Montserrat, -apple-system, 'Segoe UI', sans-serif;", cellpadding='0', cellspacing='0', role='presentation')
     tr
@@ -36,43 +36,38 @@ div(role='article', aria-roledescription='email', aria-label='Reset your Passwor
         table.sm-w-full(style='width: 600px;', cellpadding='0', cellspacing='0', role='presentation')
           tr
             td.sm-py-32.sm-px-24(style="mso-line-height-rule: exactly; padding: 48px; text-align: center; font-family: Montserrat, -apple-system, 'Segoe UI', sans-serif;")
-              a(href='https://1.envato.market/vuexy_admin', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly;")
-                img(src='images/logo.png', width='155', alt='Vuexy Admin', style='max-width: 100%; vertical-align: middle; line-height: 100%; border: 0;')
           tr
             td.sm-px-24(align='center', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly;")
               table(style='width: 100%;', cellpadding='0', cellspacing='0', role='presentation')
                 tr
                   td.sm-px-24(style="mso-line-height-rule: exactly; border-radius: 4px; background-color: #ffffff; padding: 48px; text-align: left; font-family: Montserrat, -apple-system, 'Segoe UI', sans-serif; font-size: 16px; line-height: 24px; color: #626262;")
                     p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin-bottom: 0; font-size: 20px; font-weight: 600;") Hey
-                    p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin-top: 0; font-size: 24px; font-weight: 700; color: #ff5850;") John Doe!
+                    p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin-top: 0; font-size: 24px; font-weight: 700; color: #ff5850;") #{name}
                     p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0; margin-bottom: 24px;")
-                      | A request to reset password was received from your
+                      | A request to reset password was received from your 
                       span(style='font-weight: 600;') Car Rental Service
-                      |  Account -
-                      a.hover-underline(href='mailto:john@example.com', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; color: #7367f0; text-decoration: none;") john@example.com
-                      |                           (ID: 8632698) from the IP -
-                      span(style='font-weight: 600;') 49.34.185.199
-                      |  .
-                    p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0; margin-bottom: 24px;") Use this link to reset your password and login.
-                    a(href=`${resetPasswordLink}`, style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin-bottom: 24px; display: block; font-size: 16px; line-height: 100%; color: #7367f0; text-decoration: none;") #{frontendUrl}/reset-password?token=xxxxx
+                      |  Account - 
+                      a.hover-underline(href='mailto:#{email}', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; color: #7367f0; text-decoration: none;") #{email}
+                      | .
+                    p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0; margin-bottom: 24px;") Click this button to reset your password and login.
                     table(cellpadding='0', cellspacing='0', role='presentation')
                       tr
                         td(style="mso-line-height-rule: exactly; mso-padding-alt: 16px 24px; border-radius: 4px; background-color: #7367f0; font-family: Montserrat, -apple-system, 'Segoe UI', sans-serif;")
                           a(href=`${resetPasswordLink}`, style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; display: block; padding-left: 24px; padding-right: 24px; padding-top: 16px; padding-bottom: 16px; font-size: 16px; font-weight: 600; line-height: 100%; color: #ffffff; text-decoration: none;") Reset Password &rarr;
                     p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0; margin-top: 24px; margin-bottom: 24px;")
                       span(style='font-weight: 600;') Note:
-                      |  This link is valid for 1 hour from the time it was
+                      |  This link is valid for 15 minutes from the time it was
                       |                           sent to you and can be used to change your password only once.
                     p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0;")
                       | If you did not intend to deactivate your account or need our help keeping the account, please
-                      | contact us at carrentalservice@gmail.com
-                      a.hover-underline(href='mailto:support@example.com', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; color: #7367f0; text-decoration: none;") support@example.com
+                      | contact us at 
+                      a.hover-underline(href='mailto:support@example.com', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; color: #7367f0; text-decoration: none;")  carrentalservice@gmail.com
                     table(style='width: 100%;', cellpadding='0', cellspacing='0', role='presentation')
                       tr
                         td(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; padding-top: 32px; padding-bottom: 32px;")
                           div(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; height: 1px; background-color: #eceff1; line-height: 1px;") &zwnj;
                     p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0; margin-bottom: 16px;")
-                      | Not sure why you received this email? Please
+                      | Not sure why you received this email? Please 
                       a.hover-underline(href='mailto:support@example.com', style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; color: #7367f0; text-decoration: none;") let us know
                       | .
                     p(style="font-family: 'Montserrat', sans-serif; mso-line-height-rule: exactly; margin: 0; margin-bottom: 16px;")


### PR DESCRIPTION
This pull request includes several changes to the `AuthService` and `EmailService` classes, as well as updates to the password reset email template. The main focus is on renaming methods for consistency and updating the password reset email to include a dynamic link.

### Method Renaming and Refactoring:

* [`server/src/modules/auth/auth.service.ts`](diffhunk://#diff-eab35d13c5ac358d201e1aa04e568c972b43247760dfb4928be546c494f46e6fL161-R163): Renamed `sendUserResetPasswordEmail` to `sendForgotPasswordEmail` and `sendUserVerifyEmail` to `sendVerifyEmail` for consistency. Added a console log for `resetPasswordToken`. [[1]](diffhunk://#diff-eab35d13c5ac358d201e1aa04e568c972b43247760dfb4928be546c494f46e6fL161-R163) [[2]](diffhunk://#diff-eab35d13c5ac358d201e1aa04e568c972b43247760dfb4928be546c494f46e6fL229-R228)
* [`server/src/modules/email/email.service.ts`](diffhunk://#diff-e8995598f074c67471d9d88823621074a4458eddd06734bf212430152b429dedL61-R71): Updated method names to match the changes in `auth.service.ts`. Refactored `sendForgotPasswordEmail` to include a dynamic reset password link in the email.

### Email Template Update:

* [`server/src/templates/auth/forgotPassword.pug`](diffhunk://#diff-433bae18fd798175641f2472f5d15a5636d15755da8cfb214a80f044d0ad38d8L57-R61): Updated the password reset email template to use the dynamic `resetPasswordLink` instead of a placeholder URL. [[1]](diffhunk://#diff-433bae18fd798175641f2472f5d15a5636d15755da8cfb214a80f044d0ad38d8L57-R61) [[2]](diffhunk://#diff-433bae18fd798175641f2472f5d15a5636d15755da8cfb214a80f044d0ad38d8L103)