### PR TITLE
update driving license in user

### DIFF
--- a/server/prisma/migrations/20250423021708_update/migration.sql
+++ b/server/prisma/migrations/20250423021708_update/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `drivingLicenceId` on the `users` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[userId]` on the table `driving_licences` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "users" DROP CONSTRAINT "users_drivingLicenceId_fkey";
+
+-- DropIndex
+DROP INDEX "users_drivingLicenceId_key";
+
+-- AlterTable
+ALTER TABLE "driving_licences" ADD COLUMN     "userId" TEXT;
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "drivingLicenceId";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "driving_licences_userId_key" ON "driving_licences"("userId");
+
+-- AddForeignKey
+ALTER TABLE "driving_licences" ADD CONSTRAINT "driving_licences_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema/user.prisma
+++ b/server/prisma/schema/user.prisma
@@ -13,22 +13,21 @@ enum ActionType {
 }
 
 model User {
-    id               String           @id @default(uuid())
-    email            String           @unique
-    password         String
-    firstName        String
-    lastName         String
-    phoneNumber      String?
-    isVerified       Boolean          @default(false)
-    role             Role             @default(CUSTOMER)
-    drivingLicence   DrivingLicence?  @relation(fields: [drivingLicenceId], references: [id], onDelete: Cascade)
-    bookings         Booking[]
-    drivingLicenceId String?          @unique
-    userActions      UserAction[]
-    userPreferences  UserPreference[]
-    favoriteCars     FavoriteCar[]
-    createdAt        DateTime         @default(now())
-    updatedAt        DateTime         @updatedAt
+    id              String           @id @default(uuid())
+    email           String           @unique
+    password        String
+    firstName       String
+    lastName        String
+    phoneNumber     String?
+    isVerified      Boolean          @default(false)
+    role            Role             @default(CUSTOMER)
+    drivingLicence  DrivingLicence?
+    bookings        Booking[]
+    userActions     UserAction[]
+    userPreferences UserPreference[]
+    favoriteCars    FavoriteCar[]
+    createdAt       DateTime         @default(now())
+    updatedAt       DateTime         @updatedAt
 
     @@map("users")
 }
@@ -38,9 +37,10 @@ model DrivingLicence {
     licenceNumber        String
     drivingLicenseImages String[]
     expiryDate           DateTime
+    user                 User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+    userId               String?  @unique
     createdAt            DateTime @default(now())
     updatedAt            DateTime @updatedAt
-    user                 User?
 
     @@map("driving_licences")
 }

--- a/server/src/modules/user/dtos/response.dto.ts
+++ b/server/src/modules/user/dtos/response.dto.ts
@@ -17,6 +17,10 @@ class DrivingLicenceResponseDTO implements DrivingLicence {
 
   @Exclude()
   @ApiHideProperty()
+  userId: string;
+
+  @Exclude()
+  @ApiHideProperty()
   createdAt: Date;
 
   @Exclude()
@@ -48,15 +52,15 @@ export class UserResponseDTO implements User {
   isVerified: boolean;
 
   @Expose()
-  drivingLicenceId: string;
-
-  @Expose()
   @ApiProperty({ enum: Role, enumName: 'role' })
   role: Role;
 
   @Exclude()
   @ApiHideProperty()
   password: string;
+
+  @Expose()
+  drivingLicence: DrivingLicenceResponseDTO;
 
   @Exclude()
   @ApiHideProperty()

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -12,17 +12,27 @@ export class UserService extends BaseService<User> {
     super(databaseService, 'user', UserResponseDTO);
   }
 
+  private readonly includeDrivingLicense = {
+    drivingLicence: true,
+  };
+
   async findByEmail(email: string) {
-    const user = await super.findOne({
-      email,
-    });
+    const user = await super.findOne(
+      {
+        email,
+      },
+      { include: this.includeDrivingLicense },
+    );
     return user;
   }
 
   async findById(id: string) {
-    const user = await super.findOne({
-      id,
-    });
+    const user = await super.findOne(
+      {
+        id,
+      },
+      { include: this.includeDrivingLicense },
+    );
     return user;
   }
 
@@ -41,14 +51,18 @@ export class UserService extends BaseService<User> {
       throw new BadRequestException('User not found');
     }
 
-    const drivingLicence = await this.databaseService.drivingLicence.create({
-      data: {
-        licenceNumber: dto.licenceNumber,
-        drivingLicenseImages: dto.imageUrls,
-        expiryDate: new Date(dto.expiryDate),
+    return await super.update(
+      { id },
+      {
+        drivingLicence: {
+          create: {
+            licenceNumber: dto.licenceNumber,
+            drivingLicenseImages: dto.imageUrls,
+            expiryDate: new Date(dto.expiryDate),
+          },
+        },
       },
-    });
-
-    return await super.update({ id }, { drivingLicenceId: drivingLicence.id });
+      { include: this.includeDrivingLicense },
+    );
   }
 }


### PR DESCRIPTION
This pull request refactors the relationship between `users` and `driving_licences` in the database schema and application logic. The changes remove the `drivingLicenceId` column from the `users` table and establish a new one-to-one relationship by adding a `userId` column to the `driving_licences` table. It also updates the Prisma schema, DTOs, and service methods to align with the new structure.

### Database Schema Changes:
* Dropped the `drivingLicenceId` column from the `users` table and added a `userId` column to the `driving_licences` table. A unique constraint and foreign key were added to enforce the one-to-one relationship.

### Prisma Schema Updates:
* Removed the `drivingLicenceId` field and its relation from the `User` model. Added a new relation in the `DrivingLicence` model using the `userId` field. [[1]](diffhunk://#diff-316ca41c68b8e5356e3bcb05caf8041474115c8bbb374ae13dbf14eb242bd0b0L24-L26) [[2]](diffhunk://#diff-316ca41c68b8e5356e3bcb05caf8041474115c8bbb374ae13dbf14eb242bd0b0R40-L43)

### DTO Updates:
* Updated `DrivingLicenceResponseDTO` to exclude the `userId` field from API responses.
* Updated `UserResponseDTO` to replace the `drivingLicenceId` field with the `drivingLicence` object. [[1]](diffhunk://#diff-b14baa059c9eaac8ebe1853e61ea94fb2515a749ec6a17dfb69b73ec6df67f12L50-L52) [[2]](diffhunk://#diff-b14baa059c9eaac8ebe1853e61ea94fb2515a749ec6a17dfb69b73ec6df67f12R62-R64)

### Service Layer Changes:
* Modified `UserService` to include the `drivingLicence` relation in queries for user data.
* Refactored the `updateDrivingLicence` method to create a `drivingLicence` entry directly in the `driving_licences` table and associate it with the user.